### PR TITLE
refac: endpoin de update status order, para usar o restaurantId do path

### DIFF
--- a/src/main/java/com/yourmenu/yourmenu_api/order/OrderController.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/order/OrderController.java
@@ -65,8 +65,8 @@ public class OrderController {
 
     @PatchMapping("/{orderId}")
     public ResponseEntity<OrderDTO> updateStatus(
-            @PathVariable(value = "orderId") Long orderId,
-            @RequestParam(value = "restaurantId") String restaurantId,
+            @PathVariable("restaurantId") String restaurantId,
+            @PathVariable("orderId") Long orderId,
             @RequestParam OrderStatus status) {
         OrderDTO order = orderService.updateStatus(restaurantId, orderId, status);
         return ResponseEntity.ok(order);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=yourmenu-api
 spring.profiles.active=${APP_PROFILE:dev}
 spring.jpa.open-in-view=false
-
+logging.level.org.springframework.security=DEBUG
 
 api.security.token.secret = ${JWT_SECRET:chave-default-tests}
 


### PR DESCRIPTION
# Refatoração do update order status

Antes o endpoint solicitava que fosse enviado o `restaurantId`, o que ficava algo redundante, uma vez que o `restaurantId` já está no path de `OrderController`. Então, foi reaproveitado para pegar esse valor do `path` e usá-lo na requisição.