### PR TITLE
Developer

### DIFF
--- a/src/main/java/com/yourmenu/yourmenu_api/restaurant/RestaurantService.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/restaurant/RestaurantService.java
@@ -55,7 +55,7 @@ public class RestaurantService {
     public RestaurantDTO save(RestaurantSaveDTO dto, MultipartFile profilePictureUrl, MultipartFile bannerPictureUrl, String adminId) {
         Restaurant restaurant = restaurantMapper.toEntity(dto);
         restaurantValidateService.validateAllToSave(adminId);
-        restaurant.setIsOpen(false);
+        restaurant.setIsOpen(true);
         restaurant.setSlug(restaurantSlugService.generateSlug(dto.name()));
         restaurant.setAdministrator(administratorService.findByid(adminId));
 


### PR DESCRIPTION
# Refatoração do update order status

Antes o endpoint solicitava que fosse enviado o `restaurantId`, o que ficava algo redundante, uma vez que o `restaurantId` já está no path de `OrderController`. Então, foi reaproveitado para pegar esse valor do `path` e usá-lo na requisição.