### PR TITLE
Developer

### DIFF
--- a/src/main/java/com/yourmenu/yourmenu_api/orderAdress/OrderAdress.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/orderAdress/OrderAdress.java
@@ -22,21 +22,21 @@ public class OrderAdress {
     private Order order;
 
     @ManyToOne()
-    @JoinColumn(name = "delivery_zone_id", nullable = false)
+    @JoinColumn(columnDefinition = "varchar(30)", name = "delivery_zone_id", nullable = false)
     private DeliveryZone deliveryZone;
 
-    @Column(name = "cep", nullable = false, length = 8)
-    private Long cep;
+    @Column(columnDefinition = "varchar(8)", name = "cep", nullable = false, length = 8)
+    private String cep;
 
-    @Column(name = "street", nullable = false, columnDefinition = "text")
+    @Column(columnDefinition = "varchar(50)",name = "street", nullable = false)
     private String street;
 
-    @Column(name = "number", nullable = false, length = 20)
+    @Column(columnDefinition = "varchar(10)", name = "number", nullable = false, length = 20)
     private String number;
 
-    @Column(name = "complement", length = 100)
+    @Column(columnDefinition = "text", name = "complement", length = 100)
     private String complement;
 
-    @Column(name = "reference", length = 100)
+    @Column(columnDefinition = "text", name = "reference", length = 100)
     private String reference;
 }

--- a/src/main/java/com/yourmenu/yourmenu_api/orderAdress/dto/OrderAdressDto.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/orderAdress/dto/OrderAdressDto.java
@@ -8,7 +8,7 @@ import com.yourmenu.yourmenu_api.order.dto.OrderDTO;
 public record OrderAdressDto(
         Long id,
         DeliveryZoneDto deliveryZone,
-        Long cep,
+        String cep,
         String street,
         String number,
         String complement,

--- a/src/main/java/com/yourmenu/yourmenu_api/orderAdress/dto/OrderAdressPostDto.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/orderAdress/dto/OrderAdressPostDto.java
@@ -9,14 +9,14 @@ public record OrderAdressPostDto(
         Long deliveryZoneId,
 
         @NotBlank(message = "O CEP deve ser informado")
-        @Size(min = 8, max = 8, message = "O CEP deve conter exatamente 8 caracteres")
+        @Size(min = 8, max = 8, message = "O CEP deve conter 8 caracteres")
         String cep,
 
         @NotBlank(message = "A rua deve ser informada")
         String street,
 
         @NotBlank(message = "O número deve ser informado")
-        @Size(min = 1, max = 20, message = "O número deve ter entre 1 e 20 caracteres")
+        @Size(min = 1, max = 10, message = "O número deve ter entre 1 e 20 caracteres")
         String number,
 
         @Size(max = 100, message = "O complemento deve ter no máximo 100 caracteres")

--- a/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/RestaurantAddress.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/RestaurantAddress.java
@@ -18,8 +18,8 @@ public class RestaurantAddress {
     @JoinColumn(name = "restaurant_id", nullable = false, unique = true)
     private Restaurant restaurant;
 
-    @Column(columnDefinition = "numeric(8)", nullable = false)
-    private Integer cep;
+    @Column(columnDefinition = "varchar(8)", nullable = false)
+    private String cep;
 
     @Column(nullable = false)
     private String state;

--- a/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/dto/RestaurantAddressDTO.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/dto/RestaurantAddressDTO.java
@@ -10,9 +10,8 @@ public record RestaurantAddressDTO(
     @NotBlank
     String restaurantId,
 
-    @NotNull
     @NotBlank
-    Integer cep,
+    String cep,
 
     @NotBlank
     String state,

--- a/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/dto/RestaurantAddressSaveDTO.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/dto/RestaurantAddressSaveDTO.java
@@ -2,23 +2,26 @@ package com.yourmenu.yourmenu_api.restaurantAddress.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 public record RestaurantAddressSaveDTO(
-        @NotBlank
+        @NotBlank(message = "O id do restaurante é obrigatório ser informado")
         String restaurantId,
 
-        @NotNull
-        Integer cep,
+        @NotBlank(message = "O cep é obrigatório ser informado")
+        @Size(min = 8, max = 9, message = "O cep deve conter exatamente 8 caracteres")
+        String cep,
 
-        @NotBlank
+        @NotBlank(message = "O estado é obrigatório ser informado")
         String state,
 
-        @NotBlank
+        @NotBlank(message = "A cidade é obrigatória ser informado")
         String city,
 
-        @NotBlank
+        @NotBlank(message = "A rua é obrigatória ser informado")
         String street,
 
+        @NotNull(message = "O número é obrigatório ser informado")
         Integer number,
 
         @NotBlank

--- a/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/mapper/RestaurantAddressMapper.java
+++ b/src/main/java/com/yourmenu/yourmenu_api/restaurantAddress/mapper/RestaurantAddressMapper.java
@@ -10,7 +10,7 @@ public class RestaurantAddressMapper {
     public static RestaurantAddress toEntity(RestaurantAddressSaveDTO dto, Restaurant restaurant) {
         RestaurantAddress adress = new RestaurantAddress();
         adress.setRestaurant(restaurant);
-        adress.setCep(dto.cep());
+        adress.setCep(dto.cep().replace("-", ""));
         adress.setState(dto.state());
         adress.setCity(dto.city());
         adress.setStreet(dto.street());


### PR DESCRIPTION
# Atributos de CEP com o tipo String

Foi corrigido que o atributo de `CEP` presente nas entidades de `RestaurantAdress` e `OrderAdress` que eram do tipo long, o que ignorava zeros à esquerda, para corrigir isso foram trocados para o tipo _String_.